### PR TITLE
Git clone now points to this repo, not PyTorch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Module (SEM). Here are the code for this paper.
 
 1. Clone this repository to local
 ```shell
-git clone https://github.com/pytorch/pytorch.git
+git clone https://github.com/pkuCactus/BDCN.git
 ```
 
 2. Download the imagenet pretrained vgg16 pytorch model [vgg16.pth](link: https://pan.baidu.com/s/10Tgjs7FiAYWjVyVgvEM0mA code: ab4g) or the caffemodel from the [model zoo](https://github.com/BVLC/caffe/wiki/Model-Zoo) and then transfer to pytorch version. You also can download our pretrained model for only evaluation.


### PR DESCRIPTION
Under the `Train and Evaluation` header, the `git clone` instructions were pointing to PyTorch's repo.

Now users can simply copy and paste the shell command.